### PR TITLE
Add Testcases, Fix anusvara<->മ complications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,18 +37,7 @@ jobs:
       - name: Make Schemes
         run: |
           ./build_all_schemes.sh
-
-      - name: Build Packs
+      
+      - name: Run Tests
         run: |
-          sudo ./install_all_schemes.sh
-          ./build_all_packs.sh
-
-      - name: Make Language Zips
-        run: |
-          ./build_zips.sh
-
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: all-languages
-          path: "*.zip"
+          ruby test/run.rb

--- a/schemes/ml/ml.scheme
+++ b/schemes/ml/ml.scheme
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # encoding: utf-8
 
 ##
@@ -160,8 +161,7 @@ consonants ["ra"] => "ര",
            ["na"] => "ന",
            [["na"], "Na"] => "ണ",
            ["la"] => "ല",
-           [["la"], "La"] => "ള",
-           ["ma"] => "മ"
+           [["la"], "La"] => "ള"
 
 infer_dead_consonants true
 
@@ -176,10 +176,20 @@ consonants ["rva", "rwa"] => "ര്വ",
            ["lva", "lwa"] => "ല്വ",
            "lya" => "ല്യ",
            ["Lva", "Lwa", ["lva", "lwa"]] => "ള്വ",
-           ["Lya", ["lya"]] => "ള്യ",
-           ["mva", "mwa"] => "മ്വ",
-           "mya" => "മ്യ"
+           ["Lya", ["lya"]] => "ള്യ"
 
+# BEGIN Anusvara <-> ma complications
+
+ignore_duplicates true
+anusvara [["m"]] => ["ം","ം","മ"]
+anusvara "m_" =>  ["ം","ം","മ"]
+anusvara({:accept_if => :ends_with}, "m" => ["ം","ം","മ"])
+anusvara({:accept_if => :in_between}, "m" => ["ം","ം","മ"])
+ignore_duplicates false
+
+consonants ["ma"] => "മ"
+
+# END Anusvara <-> ma complications
 
 # Autogenerate consonant vowel combinations
 generate_cv
@@ -190,14 +200,12 @@ consonants [["ru"]] => "ര്",
            [["n~", "nu"]] => "ണ്",
            [["lu"]] => "ല്",
            [["l~", "lu"]] => "ള്",
-           [["mu"]] => "മ്",
            ["r~"] => "ര്",
            ["R~"] => "റ്",
            ["n~"] => "ന്",
            ["N~"] => "ണ്",
            ["l~"] => "ല്",
-           ["L~"] => "ള്",
-           ["m~"] => "മ്"
+           ["L~"] => "ള്"
 
 # value1 = atomic chil. value2 = old style. value3 = base letter
 tag "chill" do
@@ -207,8 +215,6 @@ tag "chill" do
               ["L", ["l"]] => ["ൾ", "ള്‍", "ള"],
               ["r"] => ["ർ", "ര്‍", "ര"]
 end
-
-anusvara ["m"] => ["ം","ം","മ"]
 
 # START July 7, 2021 change
 # https://gitlab.com/subins2000/govarnam/-/issues/2
@@ -221,14 +227,6 @@ tag "chill" do
       },
       combine(get_chill, ["*_"] => ["*1", "*2", "*3"])
    )
-
-  anusvara(
-    {
-      :accept_if => :in_between,
-      :match_type => :match_exact
-    },
-    "m_" =>  ["ം","ം","മ"]
-  )
 end
 
 # END July 7, 2021 change

--- a/schemes/ml/ml.scheme
+++ b/schemes/ml/ml.scheme
@@ -180,12 +180,10 @@ consonants ["rva", "rwa"] => "ര്വ",
 
 # BEGIN Anusvara <-> ma complications
 
-ignore_duplicates true
 anusvara [["m"]] => ["ം","ം","മ"]
 anusvara "m_" =>  ["ം","ം","മ"]
 anusvara({:accept_if => :ends_with}, "m" => ["ം","ം","മ"])
 anusvara({:accept_if => :in_between}, "m" => ["ം","ം","മ"])
-ignore_duplicates false
 
 consonants ["ma"] => "മ"
 

--- a/test/ml.rb
+++ b/test/ml.rb
@@ -3,6 +3,7 @@
 class TestML < Minitest::Test
   def setup
     @varnam = get_varnam_handle('ml')
+    @varnam.config(Varnam::VARNAM_CONFIG_SET_TOKENIZER_SUGGESTIONS_LIMIT, 30)
   end
 
   def test_words
@@ -29,6 +30,16 @@ class TestML < Minitest::Test
     }
     list.each do |pattern, expected|
       assert_equal expected, @varnam.transliterate(pattern)[0].Word
+    end
+  end
+
+  def test_reverse_transliteration
+    list = {
+      'മലയാളം' => %w[malayaaLam malayaaLam_ malayALam malayALam_ malayaalam malayaalam_ malayAlam malayAlam_ malayaLam malayaLam_ malayalam malayalam_]
+    }
+
+    list.each do |word, expected|
+      assert_equal expected, @varnam.reverse_transliterate(word)
     end
   end
 end

--- a/test/ml.rb
+++ b/test/ml.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+
+class TestML < Minitest::Test
+  def setup
+    @varnam = get_varnam_handle('ml')
+  end
+
+  def test_words
+    list = {
+      'peN' => 'പെൺ',
+
+      # BEGIN Anusvara <-> ma complications
+      'am_bEdkar' => 'അംബേദ്കർ',
+      'manam_pOle' => 'മനംപോലെ',
+      'kunnamkuLam' => 'കുന്നംകുളം',
+      'pamkthi' => 'പംക്തി',
+      'kambiyil' => 'കമ്പിയിൽ',
+      'mvOnE' => 'മ്വോനേ',
+      'mvOnoossE' => 'മ്വോനൂസ്സേ',
+      'manushyan' => 'മനുഷ്യൻ',
+      'mlEchcham' => 'മ്ലേച്ചം',
+      # END Anusvara <-> ma complications
+
+      'kiLivaathil' => 'കിളിവാതിൽ',
+      'kiLivaathilil' => 'കിളിവാതിലിൽ',
+      'thaazhvara' => 'താഴ്വര',
+      'thaazh_vara' => 'താഴ്‌വര',
+      'ANkiLi' => 'ആൺകിളി'
+    }
+    list.each do |pattern, expected|
+      assert_equal expected, @varnam.transliterate(pattern)[0].Word
+    end
+  end
+end

--- a/test/run.rb
+++ b/test/run.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# encoding: utf-8
+
+require_relative '../varnam'
+
+$handles = {}
+def get_varnam_handle(scheme_id)
+  return $handles[scheme_id] if $handles[scheme_id]
+
+  if find_govarnam.nil?
+    puts "Can't find govarnam shared library."
+    exit 1
+  end
+
+  learnings_file = Tempfile.new('learnings_file')
+  $handles[scheme_id] = VarnamInstance.new(
+    "#{__dir__}/../schemes/#{scheme_id}/#{scheme_id}.vst",
+    learnings_file.path
+  )
+
+  $handles[scheme_id]
+end
+
+require "minitest/autorun"
+require_relative './ml'

--- a/varnam.rb
+++ b/varnam.rb
@@ -58,6 +58,16 @@ class VarnamInstance
     @handle = varnam_handle_ptr.read_int
   end
 
+  def config(key, value)
+    configured = VarnamLibrary.varnam_config(@handle, key, value)
+    if configured != 0
+      error_message = VarnamLibrary.varnam_get_last_error(@handle)
+      error error_message
+      return
+    end
+    true
+  end
+
   def transliterate(input)
     arr_ptr = FFI::MemoryPointer.new :pointer
     VarnamLibrary.varnam_transliterate(
@@ -81,5 +91,22 @@ class VarnamInstance
       )
     end
     sugs
+  end
+
+  def reverse_transliterate(input)
+    arr_ptr = FFI::MemoryPointer.new :pointer
+    VarnamLibrary.varnam_reverse_transliterate(
+      @handle,
+      input,
+      arr_ptr
+    )
+
+    result = []
+    size = VarnamLibrary.varray_length(arr_ptr.get_pointer(0))
+    0.upto(size - 1) do |i|
+      word_ptr = VarnamLibrary.varray_get(arr_ptr.get_pointer(0), i)
+      result.push(word_ptr.get_pointer(0).get_string(0).force_encoding('UTF-8'))
+    end
+    result
   end
 end

--- a/varnam.rb
+++ b/varnam.rb
@@ -1,0 +1,85 @@
+# encoding: utf-8
+
+def gem_available?(name)
+	require name
+rescue LoadError
+  false
+end
+
+if not gem_available?('ffi')
+  puts "Can't find gem - ffi. To install run '[sudo] gem install ffi'"
+  exit(1)
+end
+
+$library = nil
+def find_govarnam
+  return $library if not $library.nil?
+
+  # Trying to find out govarnam in the predefined locations if
+  # absolute path to the library is not specified
+  govarnam_search_paths = ['.', File.dirname(File.expand_path(__FILE__)), '/usr/local/lib', '/usr/local/lib/i386-linux-gnu', '/usr/local/lib/x86_64-linux-gnu', '/usr/lib/i386-linux-gnu', '/usr/lib/x86_64-linux-gnu', '/usr/lib']
+  govarnam_names = ['libgovarnam.so', "libgovarnam.so.#{$govarnam_major_version}", 'libgovarnam.dylib', 'varnam.dll']
+  govarnam_search_paths.each do |path|
+    govarnam_names.each do |fname|
+      fullpath = File.join(path, fname)
+      if File.exists?(fullpath)
+        $library = fullpath
+        return $library
+      end
+    end
+  end
+  nil
+end
+
+def initialize_vst_maker_handle(vst_path)
+  require_relative './varnamruby.rb'
+
+  varnam_handle_ptr = FFI::MemoryPointer.new :pointer
+
+  initialized = VarnamLibrary.vm_init(vst_path, varnam_handle_ptr)
+
+  varnam_handle = varnam_handle_ptr.read_int
+
+  if initialized != 0
+    msg = VarnamLibrary.varnam_get_last_error(varnam_handle)
+    puts "Varnam initialization failed #{msg}"
+    exit(1)
+  end
+
+  varnam_handle
+end
+
+class VarnamInstance
+  def initialize(vst_path, learnings_path)
+    require_relative './varnamruby'
+
+    varnam_handle_ptr = FFI::MemoryPointer.new :pointer
+    VarnamLibrary.varnam_init(vst_path, learnings_path, varnam_handle_ptr)
+    @handle = varnam_handle_ptr.read_int
+  end
+
+  def transliterate(input)
+    arr_ptr = FFI::MemoryPointer.new :pointer
+    VarnamLibrary.varnam_transliterate(
+      @handle,
+      1,
+      input,
+      arr_ptr
+    )
+
+    sugs = []
+    size = VarnamLibrary.varray_length(arr_ptr.get_pointer(0))
+    0.upto(size - 1) do |i|
+      word_ptr = VarnamLibrary.varray_get(arr_ptr.get_pointer(0), i)
+      vsug = VarnamLibrary::Suggestion.new(word_ptr)
+      sugs.push(
+        Suggestion.new(
+          vsug[:Word].force_encoding('UTF-8'),
+          vsug[:Weight],
+          vsug[:LearnedOn]
+        )
+      )
+    end
+    sugs
+  end
+end

--- a/varnamruby.rb
+++ b/varnamruby.rb
@@ -10,7 +10,7 @@ require 'singleton'
 # Ruby wrapper for libvarnam
 module VarnamLibrary
   extend FFI::Library
-  ffi_lib $options[:library]
+  ffi_lib $library
 
   class Symbol < FFI::Struct
     layout :Identifier, :int,
@@ -36,16 +36,22 @@ module VarnamLibrary
       :isStable, :int
   end
 
-  class Word < FFI::Struct
-    layout :text, :string,
-    :confidence, :int
+  class Suggestion < FFI::Struct
+    layout :Word, :string,
+    :Weight, :int,
+    :LearnedOn, :int
   end
 
   attach_function :varnam_debug, [:int, :int], :void
   attach_function :varnam_get_last_error, [:int], :string
   attach_function :varnam_set_vst_lookup_dir, [:string], :int
   attach_function :varnam_config, [:int, :int, :int], :int
-  attach_function :varnam_search_symbol_table , [:int, :int, Symbol.by_value, :pointer], :int
+
+  attach_function :varnam_new_search_symbol, [:pointer], :int
+  attach_function :varnam_search_symbol_table, [:int, :int, Symbol.by_value, :pointer], :int
+
+  attach_function :varnam_init, [:string, :string, :pointer], :int
+  attach_function :varnam_transliterate, [:int, :int, :string, :pointer], :int
 
   attach_function :vm_init, [:string, :pointer], :int
   attach_function :vm_create_token, [:int, :string, :string, :string, :string, :string, :int, :int, :int, :int, :int], :int
@@ -57,7 +63,7 @@ module VarnamLibrary
 end
 
 VarnamSymbol = Struct.new(:type, :pattern, :value1, :value2, :value3, :tag, :match_type, :priority, :accept_condition, :flags, :weight)
-VarnamWord = Struct.new(:text, :confidence)
+Suggestion = Struct.new(:Word, :Weight, :LearnedOn)
 VarnamSchemeDetails = Struct.new(:langCode, :identifier, :displayName, :author, :compiledDate, :isStable)
 
 module Varnam

--- a/varnamruby.rb
+++ b/varnamruby.rb
@@ -52,6 +52,7 @@ module VarnamLibrary
 
   attach_function :varnam_init, [:string, :string, :pointer], :int
   attach_function :varnam_transliterate, [:int, :int, :string, :pointer], :int
+  attach_function :varnam_reverse_transliterate, [:int, :string, :pointer], :int
 
   attach_function :vm_init, [:string, :pointer], :int
   attach_function :vm_create_token, [:int, :string, :string, :string, :string, :string, :int, :int, :int, :int, :int], :int
@@ -88,6 +89,10 @@ module Varnam
   VARNAM_CONFIG_IGNORE_DUPLICATE_TOKEN = 101
   VARNAM_CONFIG_ENABLE_SUGGESTIONS = 102
   VARNAM_CONFIG_USE_INDIC_DIGITS = 103
+  VARNAM_CONFIG_SET_DICTIONARY_SUGGESTIONS_LIMIT = 104
+  VARNAM_CONFIG_SET_PATTERN_DICTIONARY_SUGGESTIONS_LIMIT = 105
+  VARNAM_CONFIG_SET_TOKENIZER_SUGGESTIONS_LIMIT = 106
+  VARNAM_CONFIG_SET_DICTIONARY_MATCH_EXACT = 107
 
   VARNAM_TOKEN_PRIORITY_HIGH = 1
   VARNAM_TOKEN_PRIORITY_NORMAL = 0


### PR DESCRIPTION
* Allows typing "മ്ലേച്ചം" (`mlEchcham`) (Fixes bug of anusvara coming at beginning)
```
anusvara [["m"]] => ["ം","ം","മ"]
anusvara "m_" =>  ["ം","ം","മ"]
anusvara({:accept_if => :ends_with}, "m" => ["ം","ം","മ"])
anusvara({:accept_if => :in_between}, "m" => ["ം","ം","മ"])

consonants ["ma"] => "മ"
```

It used to give `mlEchcham =>  ംലേച്ചം`. There also was custom mapping for `mv => മ്വ`. These custom mappings for മ is not needed anymore with this change.

* Add unit tests for Malayalam