### PR TITLE
compile-scheme: Honor SOURCE_DATE_EPOCH

### DIFF
--- a/compile-scheme.rb
+++ b/compile-scheme.rb
@@ -192,7 +192,7 @@ def set_scheme_details()
 	d[:langCode] = FFI::MemoryPointer.from_string($scheme_details[:langCode])
 	d[:displayName] = FFI::MemoryPointer.from_string($scheme_details[:displayName])
 	d[:author] = FFI::MemoryPointer.from_string($scheme_details[:author])
-	d[:compiledDate] = FFI::MemoryPointer.from_string(Time.now.to_s)
+	d[:compiledDate] = FFI::MemoryPointer.from_string(ENV['SOURCE_DATE_EPOCH'] || Time.now.to_s)
 	if $scheme_details[:isStable].nil?
 		d[:isStable] = 0
 	else


### PR DESCRIPTION
This allows the generated vst files to become reproducible as they otherwise differ by the build date:

  -INSERT INTO metadata VALUES('scheme-compiled-date','2024-08-26 19:46:00 +0000');
  +INSERT INTO metadata VALUES('scheme-compiled-date','2024-08-26 19:56:08 +0000');

See https://reproducible-builds.org/docs/source-date-epoch/ for details

This fixes https://salsa.debian.org/input-method-team/varnam-schemes/-/jobs/6190023 

Here's a successful run with this MR applied: https://salsa.debian.org/agx/varnam-schemes/-/jobs/6190435