### PR TITLE
build: Abort on errors

### DIFF
--- a/build_all_packs.sh
+++ b/build_all_packs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 schemes=("as" "bn" "gu" "hi" "kn" "ml" "ml-inscript" "mr" "ne" "or" "pa" "sa" "ta" "te")
 for schemeID in ${schemes[@]}; do
   for packDir in schemes/$schemeID/*/ ; do

--- a/build_all_schemes.sh
+++ b/build_all_schemes.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 schemes=("as" "bn" "gu" "hi" "kn" "ml" "ml-inscript" "mr" "ne" "or" "pa" "sa" "ta" "te")
 for f in ${schemes[@]}; do
   ./build_scheme.sh $f

--- a/build_scheme.sh
+++ b/build_scheme.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 f=$1
 vst=schemes/$f/$f.vst
 ./compile-scheme.rb -s schemes/$f/$f.scheme -o $vst

--- a/build_source_with_lfs_zip.sh
+++ b/build_source_with_lfs_zip.sh
@@ -1,2 +1,4 @@
+set -e
+
 git lfs fetch
 zip -r source-with-lfs.zip . -x '.git'

--- a/build_zips.sh
+++ b/build_zips.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 cd schemes
 
 schemes=("as" "bn" "gu" "hi" "kn" "ml" "ml-inscript" "mr" "ne" "or" "pa" "sa" "ta" "te")

--- a/install_all_schemes.sh
+++ b/install_all_schemes.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 SUDO=${SUDO:-sudo}
 PREFIX=/usr/local
 


### PR DESCRIPTION
Without -e the scripts would just go on ignoring any errors possibly happening.

Notice while working on the Debian package which mostly uses `build_scheme.sh` but having it for the others looks useful too.