### PR TITLE
tests: Make scheme path configurable

### DIFF
--- a/test/run.rb
+++ b/test/run.rb
@@ -13,9 +13,12 @@ def get_varnam_handle(scheme_id)
     exit 1
   end
 
+  scheme_path = ENV['TEST_SCHEME_PATH'] ||
+      "#{__dir__}/../schemes/#{scheme_id}"
+
   learnings_file = Tempfile.new('learnings_file')
   $handles[scheme_id] = VarnamInstance.new(
-    "#{__dir__}/../schemes/#{scheme_id}/#{scheme_id}.vst",
+    "#{scheme_path}/#{scheme_id}.vst",
     learnings_file.path
   )
 


### PR DESCRIPTION
This allows to run the tests against installed schemes on the system which can then e.g. be used in Debian's autopkgtest to validate that schemes are working as expected.