### PR TITLE
ci: Skip currenty failing tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
       
       - name: Run Tests
         run: |
-          ruby test/run.rb
+          test/run.rb -e '/TestNe|TestHi/' --verbose


### PR DESCRIPTION
The Hindi and Nepali tests currently fail so let's exclude them from CI as they might otherwise mask newly introduced errors elsewhere.

I've reached for help fixing those but until then it might make sense to keep CI green so any regresions won't go unnoticed.